### PR TITLE
Add caller type (sub, eval or FORMAT) to stack trace.

### DIFF
--- a/lib/App/Stacktrace/perl_backtrace_raw.txt
+++ b/lib/App/Stacktrace/perl_backtrace_raw.txt
@@ -138,7 +138,7 @@ define perl_backtrace_an_interp
 	        if $type == $CXt_SUB
 		   set $type_name = "sub"
 	        else
-		   if $type == CXt_EVAL
+		   if $type == $CXt_EVAL
 		      set $type_name = "eval"
                    else
 		   	if $type_name = $CXt_FORMAT
@@ -369,7 +369,7 @@ define perl_backtrace_nothreads
 	        if $type == $CXt_SUB
 		   set $type_name = "sub"
 	        else
-		   if $type == CXt_EVAL
+		   if $type == $CXt_EVAL
 		      set $type_name = "eval"
                    else
 		   	if $type_name = $CXt_FORMAT
@@ -567,7 +567,7 @@ define perl_backtrace_5_8_an_interp
 	        if $type == $CXt_SUB
 		   set $type_name = "sub"
 	        else
-		   if $type == CXt_EVAL
+		   if $type == $CXt_EVAL
 		      set $type_name = "eval"
                    else
 		   	if $type_name = $CXt_FORMAT
@@ -720,7 +720,7 @@ define perl_backtrace_5_8_nothreads
 	        if $type == $CXt_SUB
 		   $type_name = "sub"
 	        else
-		   if $type == CXt_EVAL
+		   if $type == $CXt_EVAL
 		      $type_name = "eval"
                    else
 		   	if $type_name = $CXt_FORMAT

--- a/lib/App/Stacktrace/perl_backtrace_raw.txt
+++ b/lib/App/Stacktrace/perl_backtrace_raw.txt
@@ -42,7 +42,7 @@
 #perl_backtrace_5_8_an_interp
 #perl_backtrace_5_8_nothreads
 #perl_backtrace_an_interp
-#perl_backtrace_a_thread 
+#perl_backtrace_a_thread
 #perl_backtrace_nothreads
 
 set $PERL_ITHR_JOINABLE           =  0
@@ -135,6 +135,19 @@ define perl_backtrace_an_interp
                 end
             end
             if $type == $CXt_SUB || $type == $CXt_EVAL || $type == $CXt_FORMAT
+	        if $type == $CXt_SUB
+		   set $type_name = "sub"
+	        else
+		   if $type == CXt_EVAL
+		      set $type_name = "eval"
+                   else
+		   	if $type_name = $CXt_FORMAT
+			   set $type_name = "FORMAT"
+			else
+			   set $type_name = "???"
+			end
+		   end
+                end
                 set $file = 0
                 if $DEBUG
                     printf "context=%#x\n", $context
@@ -184,7 +197,7 @@ define perl_backtrace_an_interp
                         set $line = 0
                     end
                 end
-                printf "%s:%d\n", $file, $line
+                printf "%s:%d (%s)\n", $file, $line, $type_name
             else
                 if $DEBUG
                     printf "%d\t... # (context*){cx_type=%d}\n", $i, $type
@@ -353,6 +366,19 @@ define perl_backtrace_nothreads
                 end
             end
             if $type == $CXt_SUB || $type == $CXt_EVAL || $type == $CXt_FORMAT
+	        if $type == $CXt_SUB
+		   set $type_name = "sub"
+	        else
+		   if $type == CXt_EVAL
+		      set $type_name = "eval"
+                   else
+		   	if $type_name = $CXt_FORMAT
+			   set $type_name = "FORMAT"
+			else
+			   set $type_name = "???"
+			end
+		   end
+                end
                 set $file = 0
                 if $DEBUG
                     printf "context=%#x\n", $context
@@ -436,7 +462,7 @@ define perl_backtrace_nothreads
                         set $line = 0
                     end
                 end
-                printf "%s:%d\n", $file, $line
+                printf "%s:%d (%s)\n", $file, $line, $type_name
             end
             set $i = $i + 1
         end
@@ -538,6 +564,19 @@ define perl_backtrace_5_8_an_interp
                 end
             end
             if $type == $CXt_SUB || $type == $CXt_EVAL || $type == $CXt_FORMAT
+	        if $type == $CXt_SUB
+		   set $type_name = "sub"
+	        else
+		   if $type == CXt_EVAL
+		      set $type_name = "eval"
+                   else
+		   	if $type_name = $CXt_FORMAT
+			   set $type_name = "FORMAT"
+			else
+			   set $type_name = "???"
+			end
+		   end
+                end
                 set $file = 0
                 if $DEBUG
                     printf "context=%#x\n", $context
@@ -587,7 +626,7 @@ define perl_backtrace_5_8_an_interp
                         set $line = 0
                     end
                 end
-                printf "%s:%d\n", $file, $line
+                printf "%s:%d (%s)\n", $file, $line, $type_name
             else
                 if $DEBUG
                     printf "%d\t... # (context*){cx_type=%d}\n", $i, $type
@@ -678,6 +717,19 @@ define perl_backtrace_5_8_nothreads
                 end
             end
             if $type == $CXt_SUB || $type == $CXt_EVAL || $type == $CXt_FORMAT
+	        if $type == $CXt_SUB
+		   $type_name = "sub"
+	        else
+		   if $type == CXt_EVAL
+		      $type_name = "eval"
+                   else
+		   	if $type_name = $CXt_FORMAT
+			   set $type_name = "FORMAT"
+			else
+			   set $type_name = "???"
+			end
+		   end
+                end
                 if $DEBUG
                     printf "context=%#x\n", $context
                     if $context
@@ -761,7 +813,7 @@ define perl_backtrace_5_8_nothreads
                         set $line = 0
                     end
                 end
-                printf "%s:%d\n", $file, $line
+                printf "%s:%d (%s)\n", $file, $line, $type_name
             end
             set $i = $i + 1
         end
@@ -1054,7 +1106,8 @@ define perl_backtrace_5_8_9_an_interp
                         set $line = 0
                     end
                 end
-                printf "%s:%d\n", $file, $line
+                printf "%s:%d (%s)\n", $file, $line, $type_name
+
             else
                 if $DEBUG
                     printf "%d\t... # (context*){cx_type=%d}\n", $i, $type

--- a/lib/App/Stacktrace/perl_backtrace_symbols.txt
+++ b/lib/App/Stacktrace/perl_backtrace_symbols.txt
@@ -38,7 +38,7 @@ define perl_backtrace_an_interp
 	        if $type == $CXt_SUB
 		   $type_name = "sub"
 	        else
-		   if $type == CXt_EVAL
+		   if $type == $CXt_EVAL
 		      $type_name = "eval"
                    else
 		   	if $type_name = $CXt_FORMAT
@@ -115,7 +115,7 @@ define perl_backtrace_nothreads
 	        if $type == $CXt_SUB
 		   $type_name = "sub"
 	        else
-		   if $type == CXt_EVAL
+		   if $type == $CXt_EVAL
 		      $type_name = "eval"
                    else
 		   	if $type_name = $CXt_FORMAT
@@ -159,7 +159,7 @@ define perl_backtrace_5_8_an_interp
 	        if $type == $CXt_SUB
 		   $type_name = "sub"
 	        else
-		   if $type == CXt_EVAL
+		   if $type == $CXt_EVAL
 		      $type_name = "eval"
                    else
 		   	if $type_name = $CXt_FORMAT
@@ -200,7 +200,7 @@ define perl_backtrace_5_8_nothreads
 	        if $type == $CXt_SUB
 		   $type_name = "sub"
 	        else
-		   if $type == CXt_EVAL
+		   if $type == $CXt_EVAL
 		      $type_name = "eval"
                    else
 		   	if $type_name = $CXt_FORMAT
@@ -307,7 +307,7 @@ define perl_backtrace_5_8_9_an_interp
 	        if $type == $CXt_SUB
 		   $type_name = "sub"
 	        else
-		   if $type == CXt_EVAL
+		   if $type == $CXt_EVAL
 		      $type_name = "eval"
                    else
 		   	if $type_name = $CXt_FORMAT

--- a/lib/App/Stacktrace/perl_backtrace_symbols.txt
+++ b/lib/App/Stacktrace/perl_backtrace_symbols.txt
@@ -35,6 +35,19 @@ define perl_backtrace_an_interp
             set $context = $cxstack[$i]
             set $type = $context->cx_u.cx_subst.sbu_type & $CXTYPEMASK
             if $type == $CXt_SUB || $type == $CXt_EVAL || $type == $CXt_FORMAT
+	        if $type == $CXt_SUB
+		   $type_name = "sub"
+	        else
+		   if $type == CXt_EVAL
+		      $type_name = "eval"
+                   else
+		   	if $type_name = $CXt_FORMAT
+			   type_name = "FORMAT"
+			else
+			   type_name = "???"
+			end
+		   end
+                end
                 set $file = 0
                 set $cop = $context->cx_u.cx_blk.blku_oldcop
                 set $file = $cop->cop_file
@@ -42,7 +55,7 @@ define perl_backtrace_an_interp
                     set $file = "undef"
                 end
                 set $line = $cop->cop_line
-                printf "%s:%d\n", $file, $line
+                printf "%s:%d (%s)\n", $$file, $line, $type_name
             else
                 if $DEBUG
                     printf "%d\t... # (context*){cx_type=%d}\n", $i, $type
@@ -99,6 +112,19 @@ define perl_backtrace_nothreads
             set $context = $cxstack[$i]
             set $type = $context->cx_u.cx_subst.sbu_type & $CXTYPEMASK
             if $type == $CXt_SUB || $type == $CXt_EVAL || $type == $CXt_FORMAT
+	        if $type == $CXt_SUB
+		   $type_name = "sub"
+	        else
+		   if $type == CXt_EVAL
+		      $type_name = "eval"
+                   else
+		   	if $type_name = $CXt_FORMAT
+			   type_name = "FORMAT"
+			else
+			   type_name = "???"
+			end
+		   end
+                end
                 set $file = 0
                 set $cop = $context->cx_u.cx_blk.blku_oldcop
                 set $gv = $cop->cop_filegv
@@ -112,7 +138,7 @@ define perl_backtrace_nothreads
                     set $file = "undef"
                 end
                 set $line = $cop->cop_line
-                printf "%s:%d\n", $file, $line
+                printf "%s:%d (%s)\n", $$file, $line, $type_name
             end
             set $i = $i + 1
         end
@@ -130,6 +156,19 @@ define perl_backtrace_5_8_an_interp
             set $context = $cxstack[$i]
             set $type = $context->cx_type & $CXTYPEMASK
             if $type == $CXt_SUB || $type == $CXt_EVAL || $type == $CXt_FORMAT
+	        if $type == $CXt_SUB
+		   $type_name = "sub"
+	        else
+		   if $type == CXt_EVAL
+		      $type_name = "eval"
+                   else
+		   	if $type_name = $CXt_FORMAT
+			   type_name = "FORMAT"
+			else
+			   type_name = "???"
+			end
+		   end
+                end
                 set $file = 0
                 set $cop = $context->cx_u.cx_blk.blku_oldcop
                 set $file = $cop->cop_file
@@ -137,7 +176,7 @@ define perl_backtrace_5_8_an_interp
                     set $file = "undef"
                 end
                 set $line = $cop->cop_line
-                printf "%s:%d\n", $file, $line
+                printf "%s:%d (%s)\n", $$file, $line, $type_name
             else
                 if $DEBUG
                     printf "%d\t... # (context*){cx_type=%d}\n", $i, $type
@@ -158,6 +197,19 @@ define perl_backtrace_5_8_nothreads
             set $context = $cxstack[$i]
             set $type = $context->cx_type & $CXTYPEMASK
             if $type == $CXt_SUB || $type == $CXt_EVAL || $type == $CXt_FORMAT
+	        if $type == $CXt_SUB
+		   $type_name = "sub"
+	        else
+		   if $type == CXt_EVAL
+		      $type_name = "eval"
+                   else
+		   	if $type_name = $CXt_FORMAT
+			   type_name = "FORMAT"
+			else
+			   type_name = "???"
+			end
+		   end
+                end
                 set $cop = $context->cx_u.cx_blk.blku_oldcop
                 set $gv = $cop->cop_filegv
                 if $gv
@@ -171,7 +223,7 @@ define perl_backtrace_5_8_nothreads
                     set $file = "undef"
                 end
                 set $line = $cop->cop_line
-                printf "%s:%d\n", $file, $line
+                printf "%s:%d (%s)\n", $$file, $line, $type_name
             end
             set $i = $i + 1
         end
@@ -252,6 +304,19 @@ define perl_backtrace_5_8_9_an_interp
             set $context = $cxstack[$i]
             set $type = $context->cx_u.cx_subst.sbu_type & $CXTYPEMASK
             if $type == $CXt_SUB || $type == $CXt_EVAL || $type == $CXt_FORMAT
+	        if $type == $CXt_SUB
+		   $type_name = "sub"
+	        else
+		   if $type == CXt_EVAL
+		      $type_name = "eval"
+                   else
+		   	if $type_name = $CXt_FORMAT
+			   type_name = "FORMAT"
+			else
+			   type_name = "???"
+			end
+		   end
+                end
                 set $file = 0
                 set $cop = $context->cx_u.cx_blk.blku_oldcop
                 set $file = $cop->cop_file
@@ -259,7 +324,7 @@ define perl_backtrace_5_8_9_an_interp
                     set $file = "undef"
                 end
                 set $line = $cop->cop_line
-                printf "%s:%d\n", $file, $line
+                printf "%s:%d (%s)\n", $$file, $line, $type_name
             else
                 if $DEBUG
                     printf "%d\t... # (context*){cx_type=%d}\n", $i, $type

--- a/t/unthreaded.t
+++ b/t/unthreaded.t
@@ -55,7 +55,7 @@ elsif ($pstack_pid) {
         $trace,
             qr{
                 (?:
-                    ^t/unthreaded\.t:\d+\n
+                    ^t/unthreaded\.t:\d+\s\(sub\)\n
                 ){10}
             }xm
         );
@@ -66,7 +66,7 @@ elsif ($pstack_pid) {
         Test::More::is( $WAITED_RC >> 8, 0, "exit(0)" );
         Test::More::is( $WAITED_RC & 127, 0, "No signals" );
         Test::More::is( $WAITED_RC & 128, 0, "No core dump" );
-    
+
     exit;
 }
 


### PR DESCRIPTION
Ideally, for subroutines one would add the subroutine name, and for eval one would add the eval string, but that requires more work.
